### PR TITLE
Made ES credentials optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ dist/
 ccdb_output.json
 
 # Sensitive Configuration
-*.ini
+config.ini

--- a/README.md
+++ b/README.md
@@ -31,16 +31,19 @@ Arguments:
     * config file path
 * --es-host ES_HOST, -o ES_HOST
     * Elasticsearch host [env var: ES_HOST]
+    * **Required Parameter**
 * --es-port ES_PORT, -p ES_PORT
     * Elasticsearch port [env var: ES_PORT]
+    * **Required Parameter**
 * --es-username ES_USERNAME, -u ES_USERNAME
     * Elasticsearch username [env var: ES_USERNAME]
 * --es-password ES_PASSWORD, -a ES_PASSWORD
     * Elasticsearch password [env var: ES_PASSWORD]
 * --index-name INDEX_NAME, -i INDEX_NAME
     * Elasticsearch index name
+    * **Required Parameter**
 
-Though the arguments ES_HOST, ES_PORT, ES_USERNAME, ES_PASSWORD and INDEX_NAME are required, you may choose to combine those values into a config file and provide that as an argument instead.
+Though the arguments ES_HOST, ES_PORT and INDEX_NAME are required, you may choose to combine those values into a config file and provide that as an argument instead.
 
 ## Getting help
 

--- a/config_sample.ini
+++ b/config_sample.ini
@@ -1,0 +1,3 @@
+es-host = localhost
+es-port = 9200
+index-name = complaint-ccdb-local

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,9 +13,9 @@ def build_arg_parser():
         help='Elasticsearch host', env_var='ES_HOST')
     p.add('--es-port', '-p', required=True, dest='es_port', 
         help='Elasticsearch port', env_var='ES_PORT')
-    p.add('--es-username', '-u', required=True, dest='es_username', 
+    p.add('--es-username', '-u', required=False, dest='es_username', 
         help='Elasticsearch username', env_var='ES_USERNAME')
-    p.add('--es-password', '-a', required=True, dest='es_password', 
+    p.add('--es-password', '-a', required=False, dest='es_password', 
         help='Elasticsearch password', env_var='ES_PASSWORD')
     p.add('--index-name', '-i', required=True, dest='index_name', 
         help='Elasticsearch index name')
@@ -26,8 +26,8 @@ def download_and_index(parser_args):
     
     os.environ["ES_HOST"] = c.es_host
     os.environ["ES_PORT"] = c.es_port
-    os.environ["ES_USERNAME"] = c.es_username
-    os.environ["ES_PASSWORD"] = c.es_password
+    os.environ["ES_USERNAME"] = c.es_username or ''
+    os.environ["ES_PASSWORD"] = c.es_password or ''
 
     index_alias = c.index_name
     index_name = "{}-v1".format(index_alias)


### PR DESCRIPTION
Made the Elasticsearch username and password script parameters optional, as neither the Dev nor Production versions of Elasticsearch in use by cfgov-refresh require credentials

## Additions

- Added a sample configuration file (`config_sample.ini`)

## Removals

- Removed the requirement that Elasticsearch username and password be provided at runtime

## Review

- @sephcoster 
- @JeffreyMFarley 
- @amymok 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
