### PR TITLE
Added mappings for raw versions of two fields

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -21,6 +21,12 @@
       "type": "string"
     },
     "company_public_response": {
+      "fields": {
+        "raw": {
+          "index": "not_analyzed",
+          "type": "string"
+        }
+      },
       "analyzer": "cr_analyzer",
       "index": "analyzed",
       "search_analyzer": "cr_search_analyzer",
@@ -41,6 +47,13 @@
       "type": "string"
     },
     "consumer_consent_provided": {
+      "fields": {
+        "raw": {
+          "index": "not_analyzed",
+          "type": "string"
+        }
+      },
+      "index": "analyzed",
       "type": "string"
     },
     "consumer_disputed": {


### PR DESCRIPTION
Added mappings for the `raw` subfield of `company_public_response` and `consumer_consent_provided` for use by the front end

## Additions

- Mappings

## Review

- @amymok

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
