### PR TITLE
Add raw alias for string type to use in aggregation

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -57,6 +57,13 @@
       "type": "string"
     },
     "consumer_disputed": {
+      "fields": {
+        "raw": {
+          "index": "not_analyzed",
+          "type": "string"
+        }
+      },
+      "index": "analyzed",
       "type": "string"
     },
     "date_received": {


### PR DESCRIPTION
Adding raw alias for string type to use in aggregation so we don't get tokenized results

## Additions

- Added raw alias for `consumer_disputed`


## Review

- @sephcoster @AdamZarger @JeffreyMFarley 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
