### PR TITLE
Fixed boolean logic bug

### DIFF
--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -39,7 +39,7 @@ def parse_json_file(input_file_name, output_file_name):
                 n += 1
             elif (prefix, event) == ('data.item', 'end_array'):
                 new_complaint = dict(zip(my_column_array, my_data_array))
-                new_complaint["has_narrative"] = (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0)
+                new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
                 my_data_array = []
                 target.write(json.dumps(new_complaint))
                 target.write('\n')


### PR DESCRIPTION
Fixed a bug where the `has_narrative` flag was being incorrectly negated

## Changes

- Negated the boolean logic for determining if a complaint has a narrative

## Review

- @sephcoster

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
