### PR TITLE
Removed unused reference_number from indexing logic

### DIFF
--- a/complaints/index.py
+++ b/complaints/index.py
@@ -74,14 +74,10 @@ def get_es_connection():
 
 def data_load_strategy_complaint(data):
     with open(data) as f:
-        i = 0;
         for line in f.readlines():
             doc = json.loads(line)
-            if 'reference_number' not in doc:
-                doc['reference_number'] = i;
-                i += 1;
             yield {'_op_type': 'create',
-                   '_id': doc['reference_number'],
+                   '_id': doc['complaint_id'],
                    '_source':doc}
 
 


### PR DESCRIPTION
Leftover logic from internal pipeline that was assigning unused and unneeded `reference_number` to indexed records. Removed this logic.

## Removals

- Removed the incrementing `reference_number` from indexing logic

## Review

- @sephcoster 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
