### PR TITLE
Analyze company for match search

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -17,7 +17,15 @@
       "type": "string"
     },
     "company": {
-      "index": "not_analyzed",
+      "fields": {
+        "raw": {
+          "index": "not_analyzed",
+          "type": "string"
+        }
+      },
+      "analyzer": "cr_analyzer",
+      "index": "analyzed",
+      "search_analyzer": "cr_search_analyzer",
       "type": "string"
     },
     "company_public_response": {


### PR DESCRIPTION
This is part of the fix for https://github.com/cfpb/ccdb5-api/issues/19

Currently the field `company` is not being analyzed, which means we cannot do a search, but only exactly match at this point.  This will allow search to happen for this field.

## Additions

- Add analyzer to `company`


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
