### PR TITLE
Detect Partial Socrata Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ dist/
 
 # Generated Files
 ccdb_output.json
+count_data*
 
 # Sensitive Configuration
 config.ini

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -68,7 +68,7 @@ def parse_json_file(input_file_name, output_file_name, logger):
             if line_counter > 0:
                 line_count_total += line_counter
                 logger.info("Processed {} lines, {} total".format(line_counter, line_count_total))
-        except IncompleteJSONError as e:
+        except ijson.common.IncompleteJSONError as e:
             logger.info('IncompleteJSONError: {}'.format(e))
 
 

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -69,7 +69,7 @@ def parse_json_file(input_file_name, output_file_name, logger):
                 line_count_total += line_counter
                 logger.info("Processed {} lines, {} total".format(line_counter, line_count_total))
         except ijson.common.IncompleteJSONError as e:
-            logger.info('IncompleteJSONError: {}'.format(e))
+            logger.info('IncompleteJSONError! prefix: {}, event: {}, value: {}'.format(prefix, event, value))
 
 
     target.close()

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -43,30 +43,33 @@ def parse_json_file(input_file_name, output_file_name, logger):
         my_data_array = []
         my_column_array = []
 
-        for prefix, event, value in parser:
-            if prefix == 'data.item.item':
-                my_data_array.append(value)
-            elif (prefix, event) == ('data.item', 'start_array'):
-                continue
-                n += 1
-            elif (prefix, event) == ('data.item', 'end_array'):
-                new_complaint = dict(zip(my_column_array, my_data_array))
-                new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
-                my_data_array = []
-                target.write(json.dumps(new_complaint))
-                target.write('\n')
-            elif prefix == 'meta.view.columns.item.fieldName':
-                my_column_array.append(value)
+        try:
+            for prefix, event, value in parser:
+                if prefix == 'data.item.item':
+                    my_data_array.append(value)
+                elif (prefix, event) == ('data.item', 'start_array'):
+                    continue
+                    n += 1
+                elif (prefix, event) == ('data.item', 'end_array'):
+                    new_complaint = dict(zip(my_column_array, my_data_array))
+                    new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
+                    my_data_array = []
+                    target.write(json.dumps(new_complaint))
+                    target.write('\n')
+                elif prefix == 'meta.view.columns.item.fieldName':
+                    my_column_array.append(value)
 
-            line_counter += 1
-            if line_counter >= 100000:
+                line_counter += 1
+                if line_counter >= 100000:
+                    line_count_total += line_counter
+                    logger.info("Processed {} lines, {} total".format(line_counter, line_count_total))
+                    line_counter = 0
+
+            if line_counter > 0:
                 line_count_total += line_counter
                 logger.info("Processed {} lines, {} total".format(line_counter, line_count_total))
-                line_counter = 0
-
-        if line_counter > 0:
-            line_count_total += line_counter
-            logger.info("Processed {} lines, {} total".format(line_counter, line_count_total))
+        except IncompleteJSONError as e:
+            logger.info('IncompleteJSONError: {}'.format(e))
 
 
     target.close()

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -11,12 +11,13 @@ def parse_json(input_url_path, output_file_name, logger):
     # Saves downloaded file - on failure this file will remain for inspection
     tmp_file_name = "todaysData.json"
 
-    if not os.path.isfile(tmp_file_name):
-        logger.info("Downloading input data")
-        download_file = urllib.URLopener()
-        download_file.retrieve(input_url_path, tmp_file_name)
-    else:
-        logger.info("Input data file already exists")
+    if os.path.isfile(tmp_file_name):
+        logger.info("Input file exists. Deleting...")
+        os.remove(tmp_file_name)
+
+    logger.info("Downloading input file...")
+    download_file = urllib.URLopener()
+    download_file.retrieve(input_url_path, tmp_file_name)
 
     logger.info("Begin processing JSON data and writing to output file")
     parse_json_file(tmp_file_name, output_file_name, logger)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -56,7 +56,7 @@ def test_index_growing(es, index_name):
         prev_total = 0
         logger.info("count file did not exist")
     logger.info("%s >= %d" % (hits_count, prev_total))
-    assert hits_count >= prev_total
+    assert hits_count < prev_total
     with open(filename, 'w+') as f:
         f.write(str(hits_count))
     logger.info("Count written to file")

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -56,7 +56,7 @@ def test_index_growing(es, index_name):
         prev_total = 0
         logger.info("count file did not exist")
     logger.info("%s >= %d" % (hits_count, prev_total))
-    assert hits_count < prev_total
+    assert hits_count >= prev_total
     with open(filename, 'w+') as f:
         f.write(str(hits_count))
     logger.info("Count written to file")


### PR DESCRIPTION
Added logic to keep track of the total count of complaints in Socrata and prevent the pipeline from running if Socrata has less than the previously recorded amount of records. This prevents our pipeline from accidentally indexing a partial Socrata dataset.

## Additions

- Logic to obtain and record a total record count from Socrata (saves in a file)
- Logic to prevent the pipeline script from running if the Socrata count is less than the previously recorded count

## Review

- @sephcoster 
- @amymok

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
