### PR TITLE
Switched from URLOpener to requests

### DIFF
--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -2,6 +2,7 @@
 import json
 import ijson
 import urllib
+import requests
 
 # Temp File Creation
 import os
@@ -16,8 +17,11 @@ def parse_json(input_url_path, output_file_name, logger):
         os.remove(tmp_file_name)
 
     logger.info("Downloading input file...")
-    download_file = urllib.URLopener()
-    download_file.retrieve(input_url_path, tmp_file_name)
+    temp_file = open(tmp_file_name, 'w')
+    with requests.get(input_url_path, stream=True) as r:
+        temp_file.write(r.content)
+
+    temp_file.close()
 
     logger.info("Begin processing JSON data and writing to output file")
     parse_json_file(tmp_file_name, output_file_name, logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ConfigArgParse==0.11.0
 elasticsearch==2.3.0
 ijson==2.3
+requests==2.18.4


### PR DESCRIPTION
## Changes

- Pipeline now uses `requests` to download and stream the input data file instead of using the antiquated `urllib`

## Review

- @sephcoster 
- @amymok 
- @JeffreyMFarley 
- @willbarton 
- @rosskarchner 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
