### PR TITLE
Remove unused meta fields

### DIFF
--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -59,6 +59,10 @@ def parse_json_file(input_file_name, output_file_name, logger):
                 elif (prefix, event) == ('data.item', 'end_array'):
                     new_complaint = dict(zip(my_column_array, my_data_array))
                     new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
+
+                    # :updated_at and :created_at will stay since they are being used
+                    for meta in (":sid", ":id", ":meta", ":created_meta", ":position", ":updated_meta"): 
+                        del new_complaint[meta]
                     my_data_array = []
                     target.write(json.dumps(new_complaint))
                     target.write('\n')


### PR DESCRIPTION
This is related to https://github.com/cfpb/ccdb5-api/pull/52

## Removals

- Removed 6 unused meta fields from complaints before putting into elasticsearch: `":sid", ":id", ":meta", ":created_meta", ":position", ":updated_meta"`