### PR TITLE
Add new formatted dates

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -81,8 +81,16 @@
     "date_received": {
       "type": "date"
     },
+    "date_received_formatted": {
+      "type": "date",
+      "format": "MM/dd/yyyy"
+    },
     "date_sent_to_company": {
       "type": "date"
+    },
+    "date_sent_to_company_formatted": {
+      "type": "date",
+      "format": "MM/dd/yyyy"
     },
     "has_narrative": {
       "index": "not_analyzed",

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -35,6 +35,8 @@ def parse_json(input_url_path, output_file_name, logger):
     except OSError:
         print "Failed temp file removal in fake_crdb_data.py"
         pass
+def format_date(date_str):
+    return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
 
 def parse_json_file(input_file_name, output_file_name, logger):
     line_counter = 0
@@ -62,8 +64,8 @@ def parse_json_file(input_file_name, output_file_name, logger):
                 elif (prefix, event) == ('data.item', 'end_array'):
                     new_complaint = dict(zip(my_column_array, my_data_array))
                     new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
-                    new_complaint["date_received_formatted"] = datetime.strptime(new_complaint["date_received"], '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
-                    new_complaint["date_sent_to_company_formatted"] = datetime.strptime(new_complaint["date_sent_to_company"], '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
+                    new_complaint["date_received_formatted"] = format_date(new_complaint["date_received"])
+                    new_complaint["date_sent_to_company_formatted"] = format_date(new_complaint["date_sent_to_company"])
                     # :updated_at and :created_at will stay since they are being used
                     for meta in (":sid", ":id", ":meta", ":created_meta", ":position", ":updated_meta"): 
                         del new_complaint[meta]

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -7,6 +7,9 @@ import requests
 # Temp File Creation
 import os
 
+# Create new data
+from datetime import datetime
+
 
 def parse_json(input_url_path, output_file_name, logger):
     # Saves downloaded file - on failure this file will remain for inspection
@@ -59,6 +62,8 @@ def parse_json_file(input_file_name, output_file_name, logger):
                 elif (prefix, event) == ('data.item', 'end_array'):
                     new_complaint = dict(zip(my_column_array, my_data_array))
                     new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
+                    new_complaint["date_received_formatted"] = datetime.strptime(new_complaint["date_received"], '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
+                    new_complaint["date_sent_to_company_formatted"] = datetime.strptime(new_complaint["date_sent_to_company"], '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
                     # :updated_at and :created_at will stay since they are being used
                     for meta in (":sid", ":id", ":meta", ":created_meta", ":position", ":updated_meta"): 
                         del new_complaint[meta]

--- a/complaints/streamParser.py
+++ b/complaints/streamParser.py
@@ -36,6 +36,8 @@ def parse_json(input_url_path, output_file_name, logger):
         print "Failed temp file removal in fake_crdb_data.py"
         pass
 def format_date(date_str):
+    if not date_str:
+        return None
     return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S').strftime("%m/%d/%y")
 
 def parse_json_file(input_file_name, output_file_name, logger):
@@ -64,8 +66,8 @@ def parse_json_file(input_file_name, output_file_name, logger):
                 elif (prefix, event) == ('data.item', 'end_array'):
                     new_complaint = dict(zip(my_column_array, my_data_array))
                     new_complaint["has_narrative"] = (not (not new_complaint["complaint_what_happened"] or len(new_complaint["complaint_what_happened"]) == 0))
-                    new_complaint["date_received_formatted"] = format_date(new_complaint["date_received"])
-                    new_complaint["date_sent_to_company_formatted"] = format_date(new_complaint["date_sent_to_company"])
+                    new_complaint["date_received_formatted"] = format_date(new_complaint.get("date_received"))
+                    new_complaint["date_sent_to_company_formatted"] = format_date(new_complaint.get("date_sent_to_company"))
                     # :updated_at and :created_at will stay since they are being used
                     for meta in (":sid", ":id", ":meta", ":created_meta", ":position", ":updated_meta"): 
                         del new_complaint[meta]


### PR DESCRIPTION
We need a different format of dates for csv export.  So two new fields are created from their existing date fields.

## Additions

- Added `date_received_formatted` and `date_sent_to_company_formatted`
