### PR TITLE
Update the configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ dist/
 # Generated Files
 ccdb_output.json
 count_data*
+todaysData.json
 
 # Sensitive Configuration
 config.ini

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -9,21 +9,26 @@ from complaints.streamParser import parse_json
 DOC_TYPE_NAME = 'complaint'
 
 def build_arg_parser():
-    p = configargparse.ArgParser(prog='run_pipeline',
-                                 description='download complaints and index in Elasticsearch',
-                                 ignore_unknown_config_file_keys=True)
-    p.add('-c', '--my-config', required=False, is_config_file=True,
-        help='config file path')
+    p = configargparse.getArgumentParser(
+        prog='run_pipeline',
+        description='download complaints and index in Elasticsearch',
+        ignore_unknown_config_file_keys=True,
+        default_config_files=['./config.ini'],
+        args_for_setting_config_path=['-c', '--config'],
+        args_for_writing_out_config_file=['--save-config']
+    )
     p.add('--es-host', '-o', required=True, dest='es_host',
-        help='Elasticsearch host', env_var='ES_HOST')
+          help='Elasticsearch host', env_var='ES_HOST')
     p.add('--es-port', '-p', required=True, dest='es_port',
-        help='Elasticsearch port', env_var='ES_PORT')
+          help='Elasticsearch port', env_var='ES_PORT')
     p.add('--es-username', '-u', required=False, dest='es_username',
-        help='Elasticsearch username', env_var='ES_USERNAME')
+          default='',
+          help='Elasticsearch username', env_var='ES_USERNAME')
     p.add('--es-password', '-a', required=False, dest='es_password',
-        help='Elasticsearch password', env_var='ES_PASSWORD')
+          default='',
+          help='Elasticsearch password', env_var='ES_PASSWORD')
     p.add('--index-name', '-i', required=True, dest='index_name',
-        help='Elasticsearch index name')
+          help='Elasticsearch index name')
     return p
 
 
@@ -38,9 +43,12 @@ def setup_complaint_logging(doc_type_name):
     return logger
 
 
-def get_es_connection():
-    url = "{}://{}:{}".format("http", os.getenv('ES_HOST', ''), os.getenv('ES_PORT', ''))
-    es = Elasticsearch(url, http_auth=(os.getenv('ES_USERNAME', ''), os.getenv('ES_PASSWORD', '')), user_ssl=True, timeout=1000)
+def get_es_connection(config):
+    url = "{}://{}:{}".format("http", config.es_host, config.es_port)
+    es = Elasticsearch(
+        url, http_auth=(config.es_username, config.es_password),
+        user_ssl=True, timeout=1000
+    )
     return es
 
 def test_index_growing(es, index_name):
@@ -68,17 +76,12 @@ def download_and_index(parser_args):
 
     c = parser_args
 
-    os.environ["ES_HOST"] = c.es_host
-    os.environ["ES_PORT"] = c.es_port
-    os.environ["ES_USERNAME"] = c.es_username or ''
-    os.environ["ES_PASSWORD"] = c.es_password or ''
-
     index_alias = c.index_name
     index_name = "{}-v1".format(index_alias)
     backup_index_name = "{}-v2".format(index_alias)
 
     logger.info("Creating Elasticsearch Connection")
-    es = get_es_connection()
+    es = get_es_connection(c)
 
     logger.info("Testing to ensure Socrata index is stable or growing")
     test_index_growing(es, index_name)
@@ -97,7 +100,8 @@ def download_and_index(parser_args):
 
 def main():
     p = build_arg_parser()
-    c = p.parse_args()
+    c = p.parse()
+    print(p.format_values())    
     download_and_index(c)
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Default the name of the config file.  The program can be run with `python run_pipeline.py`
1. Don't rely on the environment variables
1. Dump the variables to show _where_ they are set

```
Config File (./config.ini):
  dump-config:       true
  es-host:           192.168.99.100
  es-port:           9200
  index-name:        complaint-ccdb-local
Defaults:
  -u:                
  -a:                
```

Plus some PEP8 formatting