### PR TITLE
Roll back public metadata changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DATASET_PUBLIC_CSV := complaints/ccdb/ready_s3/complaints.csv
 DATASET_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints.json
 
 METADATA_JSON := complaints/ccdb/intake/complaints_metadata.json
-#METADATA_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints_metadata.json
+METADATA_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints_metadata.json
 
 # Field Names
 
@@ -67,8 +67,7 @@ endif
 
 all: dirs check_latest $(ALL_LIST)
 
-check_latest: $(CONFIG_CCDB)
-# check_latest: dirs $(CONFIG_CCDB)
+check_latest: dirs $(CONFIG_CCDB)
 	# checking to see if there is a new dataset
 	$(PY) -m complaints.ccdb.acquire --check-latest -c $(CONFIG_CCDB) -o $(INPUT_S3_TIMESTAMP)
 
@@ -107,13 +106,12 @@ $(INDEX_CCDB): complaints/ccdb/ccdb_mapping.json $(DATASET_ND_JSON) $(METADATA_J
 	   --taxonomy complaints/taxonomy/taxonomy.txt --index-name $(ALIAS)
 	touch $@
 
-$(PUSH_S3): $(DATASET_PUBLIC_CSV) $(DATASET_PUBLIC_JSON) $(DATASET_HERO_MAP_3Y) # $(METADATA_PUBLIC_JSON)
+$(PUSH_S3): $(DATASET_PUBLIC_CSV) $(DATASET_PUBLIC_JSON) $(DATASET_HERO_MAP_3Y)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) $(DATASET_PUBLIC_JSON)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_PUBLIC_JSON)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) $(DATASET_PUBLIC_CSV)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_PUBLIC_CSV)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_HERO_MAP_3Y)
-	#$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(METADATA_PUBLIC_JSON)
 	touch $@
 
 verify_s3: $(CONFIG_CCDB)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DATASET_PUBLIC_CSV := complaints/ccdb/ready_s3/complaints.csv
 DATASET_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints.json
 
 METADATA_JSON := complaints/ccdb/intake/complaints_metadata.json
-METADATA_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints_metadata.json
+#METADATA_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints_metadata.json
 
 # Field Names
 
@@ -67,7 +67,8 @@ endif
 
 all: dirs check_latest $(ALL_LIST)
 
-check_latest: dirs $(CONFIG_CCDB)
+check_latest: $(CONFIG_CCDB)
+# check_latest: dirs $(CONFIG_CCDB)
 	# checking to see if there is a new dataset
 	$(PY) -m complaints.ccdb.acquire --check-latest -c $(CONFIG_CCDB) -o $(INPUT_S3_TIMESTAMP)
 
@@ -106,13 +107,13 @@ $(INDEX_CCDB): complaints/ccdb/ccdb_mapping.json $(DATASET_ND_JSON) $(METADATA_J
 	   --taxonomy complaints/taxonomy/taxonomy.txt --index-name $(ALIAS)
 	touch $@
 
-$(PUSH_S3): $(DATASET_PUBLIC_CSV) $(DATASET_PUBLIC_JSON) $(DATASET_HERO_MAP_3Y) $(METADATA_PUBLIC_JSON)
+$(PUSH_S3): $(DATASET_PUBLIC_CSV) $(DATASET_PUBLIC_JSON) $(DATASET_HERO_MAP_3Y) # $(METADATA_PUBLIC_JSON)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) $(DATASET_PUBLIC_JSON)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_PUBLIC_JSON)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) $(DATASET_PUBLIC_CSV)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_PUBLIC_CSV)
 	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(DATASET_HERO_MAP_3Y)
-	$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(METADATA_PUBLIC_JSON)
+	#$(PY) -m complaints.ccdb.push_s3 -c $(CONFIG_CCDB) --no-zip $(METADATA_PUBLIC_JSON)
 	touch $@
 
 verify_s3: $(CONFIG_CCDB)
@@ -154,5 +155,5 @@ $(METADATA_JSON): $(INPUT_S3_TIMESTAMP)
 	      -k $(INPUT_S3_KEY_METADATA) \
 	      -o $@
 
-$(METADATA_PUBLIC_JSON): $(METADATA_JSON)
-	sed -E '/timestamp|total_count|^{|^}/!d' $< > $@
+#$(METADATA_PUBLIC_JSON): $(METADATA_JSON)
+#	sed -E '/timestamp|total_count|^{|^}/!d' $< > $@


### PR DESCRIPTION
Rolling back the addition of public metadata to the CCDB data provisioning process due to an issue with `sed` in Jenkins. Reverts: https://github.com/cfpb/ccdb-data-pipeline/pull/44


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
