### PR TITLE
Add target for indexing complaints w/o credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ This pipeline is intended to index data in Elasticsearch and is dependent on hav
 
 Detailed instructions on how to install, configure, and get the project running are in the [INSTALL](INSTALL.md) document.
 
-## Usage
+## Usage (Users)
+
+1. Set environment variables
+    1. `export ES_USERNAME=<foo>`
+    1. `export ES_PASSWORD=<bar>`
+    1. `export ENV=[ENVIRONMENT]`
+        1. where ENVIRONMENT=`dev`, `staging`, `prod`
+1. `make from_public`
+
+## Usage (Developers)
 
 1. `source ./activate-virtualenv.sh`
 1. Set environment variables
@@ -29,11 +38,6 @@ Detailed instructions on how to install, configure, and get the project running 
     1. `export OUTPUT_S3_BUCKET=<bucket-name>`
     1. `export OUTPUT_S3_FOLDER=ccdb/test/<your initials>`
 1. `make`
-
-## Getting help
-
-Instruct users how to get help with this software; this might include links to an issue tracker, wiki, mailing list, etc.
-
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)


### PR DESCRIPTION
This command will allow users to index complaints into Elasticsearch without requiring AWS credentials

#### How to test

###### Terminal 1

Start CFGOV and the Elasticsearch service

```
cd cfgov-refresh
docker-compose up
```

###### Terminal 2

```
cd cfpb/ccdb-data-pipeline
# pull down and check out this PR
unset AWS_ACCESS_KEY_ID
unset AWS_SECRET_ACCESS_KEY
make from_public
```

###### Browser window 

1. http://localhost:8000/data-research/consumer-complaints/search/?dataNormalization=None&dateInterval=All
1. Verify you see the new records

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
