### PR TITLE
Build metadata that can be statically loaded in a JS app

### DIFF
--- a/common/tests/__init__.py
+++ b/common/tests/__init__.py
@@ -41,6 +41,22 @@ def noop_coroutine(options, outfile):
         yield i
 
 
+def validate_files(actual_file, expected_file):
+    import io
+
+    with io.open(actual_file, 'r', encoding='utf-8') as f:
+        actuals = [l for l in f]
+
+    with io.open(expected_file, 'r', encoding='utf-8') as f:
+        expecteds = [l for l in f]
+
+    assert len(actuals) == len(expecteds)
+
+    for i, act in enumerate(actuals):
+        assert act == expecteds[i], '[{}]\nexp==>{}<==\nact==>{}<=='.format(
+            i, expecteds[i], act)
+
+
 def validate_json(actual_file, expected_file):
     import io
 

--- a/complaints/ccdb/build_metadata_javascript.py
+++ b/complaints/ccdb/build_metadata_javascript.py
@@ -1,0 +1,59 @@
+import errno
+import io
+import json
+import sys
+
+import configargparse
+
+VALID_ATTR = ['metadata_timestamp', 'qas_timestamp', 'total_count']
+
+# -----------------------------------------------------------------------------
+# Process
+# -----------------------------------------------------------------------------
+
+
+def load_metadata(filename):
+    with io.open(filename, 'r', encoding='utf-8') as f:
+        try:
+            jo = json.load(f)
+        except Exception:
+            print("'{0}' is not a valid JSON document.".format(filename),
+                  file=sys.stderr)
+            sys.exit(errno.ENOENT)
+    return jo
+
+
+def save_javascript(metadata, filename):
+    try:
+        with io.open(filename, 'w', encoding='utf-8') as f:
+            f.write('var complaint_public_metadata = ')
+            json.dump(metadata, f, indent=2, sort_keys=True)
+    except Exception:
+        print("Unable to write '{0}'".format(filename), file=sys.stderr)
+        sys.exit(errno.EIO)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+
+def build_arg_parser():
+    p = configargparse.ArgParser(
+        prog='build_metadata_javascript',
+        description='makes metadata that can be statically loaded in a JS app'
+    )
+    p.add('infile', help="The name of the public metadata file")
+    p.add('outfile', help="The name of the Javascript file")
+    return p
+
+
+def main():
+    p = build_arg_parser()
+    options = p.parse_args()
+
+    save_javascript(load_metadata(options.infile), options.outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/complaints/ccdb/tests/__fixtures__/metadata.js
+++ b/complaints/ccdb/tests/__fixtures__/metadata.js
@@ -1,0 +1,5 @@
+var complaint_public_metadata = {
+  "metadata_timestamp": "2019-09-09 09:10:53",
+  "qas_timestamp": "2019-09-09 00:00:00",
+  "total_count": 2213573
+}

--- a/complaints/ccdb/tests/test_build_metadata_javascript.py
+++ b/complaints/ccdb/tests/test_build_metadata_javascript.py
@@ -1,0 +1,71 @@
+import io
+import os
+import unittest
+from unittest.mock import mock_open, patch
+
+import complaints.ccdb.build_metadata_javascript as sut
+from common.tests import build_argv, captured_output, validate_files
+
+
+def fixtureToAbsolute(fixture_file):
+    # where is _this_ file?
+    thisScriptDir = os.path.dirname(__file__)
+
+    return os.path.join(thisScriptDir, '__fixtures__', fixture_file)
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.actual_file = fixtureToAbsolute('a.tmp')
+        self.positional = [
+            fixtureToAbsolute('metadata_public.json'),
+            self.actual_file
+        ]
+
+    def tearDown(self):
+        try:
+            os.remove(self.actual_file)
+        except Exception:
+            pass
+
+    def test_main_happy_path(self):
+        argv = build_argv(positional=self.positional)
+        with captured_output(argv) as (out, err):
+            sut.main()
+
+        validate_files(self.actual_file, fixtureToAbsolute('metadata.js'))
+
+        console_output = out.getvalue()
+        self.assertEqual(console_output, '')
+
+    def test_bad_input(self):
+        self.positional[0] = fixtureToAbsolute('exp_s3.ndjson')
+
+        with self.assertRaises(SystemExit) as ex:
+            argv = build_argv(positional=self.positional)
+            with captured_output(argv) as (out, err):
+                sut.main()
+
+        self.assertEqual(ex.exception.code, 2)
+
+        console_output = err.getvalue()
+        self.assertIn('exp_s3.ndjson', console_output)
+        self.assertIn('is not a valid JSON document', console_output)
+
+    def test_cant_write(self):
+        m = mock_open()
+        m.side_effect = IOError
+
+        with self.assertRaises(SystemExit) as ex:
+            with patch.object(io, 'open', m):
+                with captured_output([]) as (out, err):
+                    sut.save_javascript({}, 'foo')
+
+        self.assertEqual(ex.exception.code, 5)
+
+        console_output = err.getvalue()
+        self.assertIn("Unable to write 'foo'",  console_output)


### PR DESCRIPTION
This pull request is one of three PRs required to implement a new feature.

- [CCDB UI](https://github.com/cfpb/ccdb5-ui/pull/251)
- [CF GOV Refresh](https://github.com/cfpb/cfgov-refresh/pull/5723)

A full explanation of the feature is [here](https://github.com/cfpb/ccdb5-ui/pull/251)

## Testing

`tox`

:100:

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
