### PR TITLE
Add mapping for event_tag field

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -92,6 +92,10 @@
       "type": "date",
       "format": "MM/dd/yyyy"
     },
+    "event_tag": {
+      "index": "not_analyzed",
+      "type": "string"
+    },
     "has_narrative": {
       "index": "not_analyzed",
       "type": "boolean"


### PR DESCRIPTION
Following https://github.com/cfpb/ccdb-data-pipeline/pull/49, we need to tell Elasticsearch how to process the new fields

## How to test

1. Start a terminal window
1. Set the AWS credentials in the environment variables
1. Start Elasticsearch

#### Doesn't break V1

Verify these changes are invisible to the current process

```
make clean
make elasticsearch
```

1. http://localhost:9200/complaint-public-dev/_search
1. Ctrl+F for `event_tag` => no results

#### Supports new V2 field

1. Restart Elasticsearch

```
export INPUT_S3_BUCKET="files.consumerfinance.gov"
export INPUT_S3_KEY="ccdb/test/jmf/v2_complaints.csv"
export INPUT_S3_KEY_METADATA="ccdb/test/jmf/complaints_metadata.json"

make clean
make elasticsearch
```

1. http://localhost:9200/complaint-public-dev/_search
1. Ctrl+F for `event_tag` => some results are `null` some have values

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
