### PR TITLE
Improve make from_public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ PUSH_S3 := complaints/ccdb/ready_s3/.last_pushed
 
 # URLs
 
-URL_PUBLIC_CSV := http://files.consumerfinance.gov/ccdb/complaints.csv
-URL_PUBLIC_METADATA := http://files.consumerfinance.gov/ccdb/complaints_metadata.json
+URL_PUBLIC_CSV ?= https://files.consumerfinance.gov/ccdb/complaints.csv
+URL_PUBLIC_METADATA ?= https://files.consumerfinance.gov/ccdb/complaints_metadata.json
 
 # Verification
 
@@ -87,14 +87,9 @@ elasticsearch: dirs check_latest $(INDEX_CCDB)
 
 
 from_public: dirs
+	@# This will get the date modified header: curl -L -sI $(URL_PUBLIC_CSV)
 	touch $(INPUT_S3_TIMESTAMP)
 	curl -L -o $(DATASET_CSV) $(URL_PUBLIC_CSV)
-	$(PY) -m complaints.ccdb.choose_field_map --target-format JSON \
-	                                          $(DATASET_CSV) $(FIELDS_S3_JSON)
-	$(PY) common/csv2json.py --limit $(MAX_RECORDS) --json-format NDJSON \
-	                         --fields $(FIELDS_S3_JSON) \
-	                         $(DATASET_CSV) \
-	                         $(DATASET_ND_JSON)
 	curl -L -o $(METADATA_JSON) $(URL_PUBLIC_METADATA)
 	$(MAKE) $(INDEX_CCDB)
 


### PR DESCRIPTION
A few tweaks:

1. Changed `http` to `https` for the public URLs.  They were getting redirected anyway
1. Simplified the `from_public` action.  The removed lines are redundant
1. Made it so that `URL_PUBLIC_CSV`and `URL_PUBLIC_METADATA` can be overridden by environment variables

## Testing

Start Elasticsearch

```
export URL_PUBLIC_CSV=https://files.consumerfinance.gov/ccdb/v2_complaints.csv
make from_public
```
1. http://localhost:9200/complaint-public-dev/_search
1. Ctrl+F for `event_tag` => some results are `null` some have values

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
