### PR TITLE
Run the CI workflow in Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install Python dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 skipsdist=True
-envlist=lint-py37, unittest-py37
+envlist=lint-py36, unittest-py36
 
 [testenv]
 passenv = *
 basepython=
-    py37: python3.7
+    py36: python3.6
 
 commands=
     unittest:           {[unittest]commands}
@@ -18,7 +18,7 @@ commands=
     
 # ------------------------------------------------------------------------------
 
-[testenv:lint-py37]
+[testenv:lint-py36]
 deps=
     flake8
     isort
@@ -26,7 +26,7 @@ commands=
     flake8
     isort --check-only --diff .
 
-[testenv:unittest-py37]
+[testenv:unittest-py36]
 setenv=
     PYTHONDONTWRITEBYTECODE=1
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
Unit tests and GitHub actions were set up to run in Python 3.7,
but the code will be executed in production in Python 3.6, so
this keeps versions closer to reality.

Tests succeed in 3.6.