### PR TITLE
Pin the elasticsearch library to 7.13.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.11.7
 ConfigArgParse==0.14.0
-elasticsearch>=7.0.0,<8.0.0
+elasticsearch==7.13.4
 ijson==2.4
 pytz
 requests==2.22.0


### PR DESCRIPTION
The code in this repo has been indexing CCDB data to AWS Elasticsearch 7.9.1
since March. On Aug. 3, python elasticsearch released version 7.14.0 of its library,
which was installed in the Jenkins jobs, which caused the DEV and EXT indexing jobs
to fail with a version conflict.

Stepping the python library back to the version we had used for months -- 7.13.4 --
fixes the issue and puts us on a version that works in AWS Elasticsearch 7.9.1
and should continue working if we upgrade to the next version availabe in AWS.

This fix has been tested manually in the zusa and EXT Jenkins jobs.