### PR TITLE
Adjust mappings+settings to ignore periods in company names

### DIFF
--- a/complaints/ccdb/ccdb_mapping.json
+++ b/complaints/ccdb/ccdb_mapping.json
@@ -11,8 +11,8 @@
           "type": "keyword"
         },
         "suggest": {
-          "analyzer": "uppercase_analyzer",
-          "type": "text"
+          "type": "completion",
+          "analyzer": "entity"
         }
       },
       "analyzer": "cr_analyzer",

--- a/complaints/settings.json
+++ b/complaints/settings.json
@@ -28,7 +28,19 @@
         "token_separator": " "
       }
     },
+    "char_filter": {
+      "entity": {
+        "type": "pattern_replace",
+        "pattern": "\\.",
+        "replacement": ""
+      }
+    },
     "analyzer": {
+      "entity": {
+        "type": "custom",
+        "tokenizer": "keyword",
+        "char_filter": ["entity"]
+      },
       "cr_analyzer": {
         "type": "custom",
         "tokenizer": "whitespace",


### PR DESCRIPTION
The suggester for the 'Company name' filter gets led astray when company names have periods in them, such as 'U.S. Bancorp' If a user types in 'US Banc', nothing is suggested.

This change adds a filter and analyzer for Company name suggestions that ignores periods, so that either 'US Banc' or 'U.S. Banc' will suggest U.S. BANCORP.

This satisfies internal issue 2209. It works in Complaint Explorer, and will be tested in CCDB on a DEV server with reindexed data.

