### PR TITLE
Bump the indexing timeout value

### DIFF
--- a/common/es_proxy.py
+++ b/common/es_proxy.py
@@ -29,7 +29,7 @@ def get_es_connection(config):
     url = "{}://{}:{}".format("http", config.es_host, config.es_port)
     es = Elasticsearch(
         url, http_auth=(config.es_username, config.es_password),
-        user_ssl=True, timeout=1000
+        user_ssl=True, timeout=2000
     )
     return es
 

--- a/common/tests/test_es_proxy.py
+++ b/common/tests/test_es_proxy.py
@@ -24,5 +24,5 @@ class TestEdges(unittest.TestCase):
         mock_es.assert_called_once_with(
             'http://www.example.org:9222',
             http_auth=('king', 'kong'),
-            timeout=1000,
+            timeout=2000,
             user_ssl=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 skipsdist=True
-envlist=lint-py36, unittest-py36
+envlist=lint-py311, unittest-py311
 
 [testenv]
 passenv = *
 basepython=
-    py36: python3.6
+    py311: python3.11
 
 commands=
     unittest:           {[unittest]commands}


### PR DESCRIPTION
Indexing on EXT Jenkins has become troublesome, possibly because of the increased load on the server from more aggressive security scanning and heavy morning cron jobs.

Two types of errors have interrupted indexing:
- Disconnects with S3
- Timeouts during OpenSearch indexing

These appear to be specific to EXT Jenkins, because our DEV Jenkins instance (zusa) runs the same pipeline code against the same data, at the same time of the morning, and rarely fails to finish.

The S3 interruptions are not too disruptive, because the downloads that succeed won't have to be run again on a retry, and little time is lost.

The timeout error, however, is painful when indexing bombs late in the indexing run. In the last week, a timeout stopped indexing after 4 million complaints had been indexed, which causes the job to start over from 0.

This PR doubles the OpenSearch timeout value, which should not affect most runs, but could save the occasional late timeout.

I ran this morning's CCDB indexing using this branch, and it succeeded on the first try. That doesn't prove that the new value saved the run, but I think we should see if the new timeout reduces the churn.

## Testing
In addition to test-running the new timeout value, I got the unit tests running again by upgrading python to 3.11 and adjusting the tox configs.
