### PR TITLE
Update python to an available version (3.11.7) for ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.11.7
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
We need to upgrade python to an available version for CI testing
