### PR TITLE
Apply a bigger timeout limit, again

### DIFF
--- a/common/es_proxy.py
+++ b/common/es_proxy.py
@@ -47,7 +47,7 @@ def get_aws_es_connection(config):
         use_ssl=True,
         verify_certs=True,
         connection_class=RequestsHttpConnection,
-        timeout=1000
+        timeout=2000
     )
 
     print(es.info())


### PR DESCRIPTION
When I bumped the indexing timeout I missed a reference that happened to be the most important one, in the aws_es_connection.
