### PR TITLE
DATAP-1682 Stop using readlines() on the main json source file

### DIFF
--- a/complaints/ccdb/index_ccdb.py
+++ b/complaints/ccdb/index_ccdb.py
@@ -115,7 +115,7 @@ def load_json(logger, file):
 
 def data_load_strategy_complaint(data, transform_fn):
     with open(data) as f:
-        for line in f.readlines():
+        for line in f:
             doc = transform_fn(json.loads(line))
             yield {'_op_type': 'index',
                    '_id': doc['complaint_id'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ConfigArgParse==0.14.0
 elasticsearch==7.13.4
 ijson==2.4
 pytz
-requests==2.22.0
+requests==2.32.3
 requests_aws4auth==0.8.0


### PR DESCRIPTION
As noted by @chosak, calling `readlines()` on an opened file loads  the entire file in memory, as opposed to iterating on the opened file object directly, which is a generator that streams results.

This delivered a performance boost that allowed our indexing run to succeed on the first try.

Documented in internal GHE issue 2974.  