### PR TITLE
Add support for running indexing pipeline in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**
+!common
+!complaints
+!config_sample.ini
+!Makefile
+!requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.13-alpine
 
 ENV LANG=en_US.UTF-8
 ENV PIP_NO_CACHE_DIR=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY . .
 RUN apk update --no-cache && \
     apk upgrade --no-cache --ignore alpine-baselayout && \
     apk add --no-cache \
+        aws-cli \
+        jq \
         make
 
 RUN pip install --upgrade pip setuptools && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.8-alpine
+
+ENV LANG=en_US.UTF-8
+ENV PIP_NO_CACHE_DIR=true
+ENV PYTHONUNBUFFERED=1
+ENV HOME=/usr/home
+
+WORKDIR ${HOME}
+
+COPY . .
+
+RUN apk update --no-cache && \
+    apk upgrade --no-cache --ignore alpine-baselayout && \
+    apk add --no-cache \
+        make
+
+RUN pip install --upgrade pip setuptools && \
+    pip install -r ./requirements.txt
+
+# Don't run as the root user.
+ARG USER=base
+RUN adduser -g ${USER} --disabled-password ${USER}
+RUN chown -R ${USER}:${USER} ${HOME}
+
+USER ${USER}

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,19 @@ clean:
 dirs:
 	for dir in $(DIRS) ; do [ -d $$dir ] || mkdir -p $$dir ; done
 
-elasticsearch: dirs check_latest $(INDEX_CCDB)
+elasticsearch: dirs check_latest
+	@get_timestamp() { \
+		ls -l "$$1" 2>/dev/null | awk '{print $$6, $$7, $$8}' || echo 'none'; \
+	}; \
+	echo "S3 dataset timestamp: $$(get_timestamp $(INPUT_S3_TIMESTAMP))"; \
+	echo "Last index timestamp: $$(get_timestamp $(INDEX_CCDB))"
+	@if [ -n "$(FORCE_REINDEX)" ] || \
+		[ ! -f $(INDEX_CCDB) ] || \
+		[ $(INPUT_S3_TIMESTAMP) -nt $(INDEX_CCDB) ]; then \
+		$(MAKE) $(INDEX_CCDB); \
+	else \
+		echo "Data already indexed, nothing to do"; \
+	fi
 
 
 from_public: dirs

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ OS_NAME := $(shell uname -s | tr A-Z a-z)
 # "SOCRATA_JSON" = {metadata: {}, data: [[], [], []]}
 # ND-JSON = {}\n{}\n{}\n
 
-DIRS := complaints/ccdb/intake complaints/ccdb/ready_es complaints/ccdb/ready_s3
+STATE_DIR := complaints/ccdb
+DIRS := $(STATE_DIR)/intake $(STATE_DIR)/ready_es $(STATE_DIR)/ready_s3
 MAX_RECORDS ?= 0
 
 # Aliases
@@ -15,25 +16,25 @@ ALIAS := complaint-public-$(ENV)
 
 CONFIG_CCDB := config-ccdb.ini
 
-DATASET_CSV := complaints/ccdb/intake/complaints.csv
-DATASET_ND_JSON := complaints/ccdb/ready_es/complaints.json
-DATASET_PUBLIC_CSV := complaints/ccdb/ready_s3/complaints.csv
-DATASET_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints.json
+DATASET_CSV := $(STATE_DIR)/intake/complaints.csv
+DATASET_ND_JSON := $(STATE_DIR)/ready_es/complaints.json
+DATASET_PUBLIC_CSV := $(STATE_DIR)/ready_s3/complaints.csv
+DATASET_PUBLIC_JSON := $(STATE_DIR)/ready_s3/complaints.json
 
-METADATA_JAVASCRIPT := complaints/ccdb/ready_s3/metadata.js
-METADATA_JSON := complaints/ccdb/intake/complaints_metadata.json
-METADATA_PUBLIC_JSON := complaints/ccdb/ready_s3/complaints_metadata.json
+METADATA_JAVASCRIPT := $(STATE_DIR)/ready_s3/metadata.js
+METADATA_JSON := $(STATE_DIR)/intake/complaints_metadata.json
+METADATA_PUBLIC_JSON := $(STATE_DIR)/ready_s3/complaints_metadata.json
 
 # Field Names
 
-FIELDS_S3_CSV := complaints/ccdb/intake/fields-s3-csv.txt
-FIELDS_S3_JSON := complaints/ccdb/intake/fields-s3-json.txt
+FIELDS_S3_CSV := $(STATE_DIR)/intake/fields-s3-csv.txt
+FIELDS_S3_JSON := $(STATE_DIR)/intake/fields-s3-json.txt
 
 # Sentinels
 
-INDEX_CCDB := complaints/ccdb/ready_es/.last_indexed
-INPUT_S3_TIMESTAMP := complaints/ccdb/intake/.latest_dataset
-PUSH_S3 := complaints/ccdb/ready_s3/.last_pushed
+INDEX_CCDB := $(STATE_DIR)/ready_es/.last_indexed
+INPUT_S3_TIMESTAMP := $(STATE_DIR)/intake/.latest_dataset
+PUSH_S3 := $(STATE_DIR)/ready_s3/.last_pushed
 
 # URLs
 
@@ -42,8 +43,8 @@ URL_PUBLIC_METADATA ?= https://files.consumerfinance.gov/ccdb/complaints_metadat
 
 # Verification
 
-S3_JSON_COUNT := complaints/ccdb/verification/json_prev_size.txt
-AKAMAI_CACHE_COUNT := complaints/ccdb/verification/cache_prev_size.txt
+S3_JSON_COUNT := $(STATE_DIR)/verification/json_prev_size.txt
+AKAMAI_CACHE_COUNT := $(STATE_DIR)/verification/cache_prev_size.txt
 
 # Defaults
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.11.7
+boto3==1.37.38
 ConfigArgParse==0.14.0
 elasticsearch==7.13.4
 ijson==2.4


### PR DESCRIPTION
This PR adds a Dockerfile to this project, which allows for running its data pipelines in Docker.

The Dockerfile uses Python 3.13 instead of the [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov) version 3.8. There are several vulnerabilities in Python 3.8 (which is EOL) and the indexing doesn't have to run using the same Python version as the API code. In order to support this upgrade, the version of boto has been updated from 1.11.7 to 1.37.38, which is [the last version to support 3.8](https://github.com/boto/boto3/blob/develop/CHANGELOG.rst).

The `make elasticsearch` logic has been modified so that checking if we need to reindex (based on sentinel files containing last dataset/index times) doesn't rely on the local presence of the dataset files. Currently, this pipeline is assumed to run somewhere with a persistent Jenkins workspace, meaning that the (large) dataset files will be present locally. In an ephemeral Jenkins setup, we don't have such a persistent workspace. This change in logic is intended to support a workflow where we (1) download only the (small) sentinel files from a persistent place (S3); (2) check those file timestamps to see if we need to reindex; (3) only download the large source data if we need to reindex (or if the `FORCE_REINDEX` environment variable is set).

## Testing

First, build the Docker image:

```sh
docker build -t ccdb-data-pipeline:latest .
```

Then, run the indexing pipeline, making sure to pass valid AWS credentials that can read the source S3 bucket:

```sh
 docker run \
    -e ENV=local \
    -e INPUT_S3_BUCKET=<name of your bucket> \
    -e INPUT_S3_KEY=path/to/consumer_complaint_datashare.csv \
    -e INPUT_S3_KEY_METADATA=path/to/consumer_complaint_datashare_metadata.json \
    -e AWS_ACCESS_KEY_ID \
    -e AWS_SECRET_ACCESS_KEY \
    -e AWS_SESSION_TOKEN \
    -e ES_HOST=host.docker.internal \
    -e FORCE_REINDEX=1 \
    -v /tmp:/state \
    ccdb-data-pipeline:latest \
    make STATE_DIR=/state elasticsearch
```

The above example uses `host.docker.internal` to connect to an Elasticsearch running on your local machine. Alternatively pass `ES_PORT`, `ES_USERNAME`, and `ES_PASSWORD` to connect to a remote Elasticsearch. It also mounts your local `/tmp` directory as the place where files are downloaded/checked.

## Todos

- So far I've only tested the indexing pipeline; there are other pipelines that may need to be migrated as well.
- This Dockerfile works properly to index into an Elasticsearch 7.x index. In order for this project to work to index into OpenSearch 2.x (our target environment) it must be modified to use a more modern OS library instead of the current ES one. I'm planning to open an additional PR to add this support but wanted to keep this piece separate.
