### PR TITLE
Add BATCH_SIZE env var

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -7,6 +7,9 @@ export VENV_NAME="ccdb-data-pipeline"
 # set this value to limit the number of records to load to reduce load time
 # export MAX_RECORDS=10000
 
+# set an optional batch size for bulk indexing runs; defaults to 2000
+# export BATCH_SIZE=5000
+
 # export INPUT_S3_BUCKET="foo"
 # export INPUT_S3_KEY="bar"
 # export INPUT_S3_KEY_METADATA="barrr"

--- a/complaints/ccdb/index_ccdb.py
+++ b/complaints/ccdb/index_ccdb.py
@@ -1,5 +1,4 @@
 import json
-import configargparse
 import os
 import sys
 from functools import partial
@@ -13,7 +12,6 @@ from common.date import (format_date_as_mdy, format_date_est,
 from common.es_proxy import (add_basic_es_arguments, get_aws_es_connection,
                              get_es_connection)
 from common.log import setup_logging
-
 
 BATCH_SIZE = os.getenv("BATCH_SIZE", 2000)
 

--- a/complaints/ccdb/index_ccdb.py
+++ b/complaints/ccdb/index_ccdb.py
@@ -1,4 +1,6 @@
 import json
+import configargparse
+import os
 import sys
 from functools import partial
 
@@ -11,6 +13,9 @@ from common.date import (format_date_as_mdy, format_date_est,
 from common.es_proxy import (add_basic_es_arguments, get_aws_es_connection,
                              get_es_connection)
 from common.log import setup_logging
+
+
+BATCH_SIZE = os.getenv("BATCH_SIZE", 2000)
 
 # -----------------------------------------------------------------------------
 # Enhancing Functions
@@ -137,7 +142,7 @@ def yield_chunked_docs(get_data_function, data, chunk_size):
 
 def index_json_data(
     es, logger, doc_type_name, settings_json, mapping_json, data, index_name,
-    backup_index_name, alias, chunk_size=2000, qas_timestamp=0
+    backup_index_name, alias, chunk_size=BATCH_SIZE, qas_timestamp=0
 ):
     settings = load_json(logger, settings_json)
     mapping = load_json(logger, mapping_json)


### PR DESCRIPTION
Add an optional env var for controlling indexing batch size.

This change shouldn't affect daily legacy AWS indexing, because we don't control
batch size there. The default batch of 2,000 should be unchanged.

This patch will allow altering the BATCH_SIZE in Alto for indexer testing to find
a sweet spot for indexing speed.

Tox tests pass.