### PR TITLE
Minor indexing optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,14 @@ ENV HOME=/usr/home
 
 WORKDIR ${HOME}
 
+# Add Zscaler Root CA certificate, rebuild CA certificates, and both the root
+# cert and the rebuilt ca-certificates cert to APP_HOME for reuse.
+ADD https://raw.githubusercontent.com/cfpb/zscaler-cert/3982ebd9edf9de9267df8d1732ff5a6f88e38375/zscaler_root_ca.pem ${HOME}/zscaler-root-public.cert
+RUN cp ${HOME}/zscaler-root-public.cert /usr/local/share/ca-certificates/zscaler-root-public.cert && \
+    apk add ca-certificates --no-cache --no-check-certificate && \
+    update-ca-certificates && \
+    cp /etc/ssl/certs/ca-certificates.crt ${HOME}/ca-certificates.crt
+
 COPY . .
 
 RUN apk update --no-cache && \

--- a/common/csv2json.py
+++ b/common/csv2json.py
@@ -1,11 +1,11 @@
 import csv
 import errno
 import io
-import json
 import sys
 from itertools import count
 
 import configargparse
+import orjson
 
 # -----------------------------------------------------------------------------
 # Unicode CSV Iterator
@@ -28,7 +28,7 @@ def saveNewlineDelimitedJson(options):
         try:
             for i in count():  # pragma: no branch
                 row = yield i
-                f.write(json.dumps(row))
+                f.write(orjson.dumps(row).decode('utf-8'))
                 f.write('\n')
         finally:
             pass
@@ -44,7 +44,7 @@ def saveStandardJson(options):
             for i in count():  # pragma: no branch
                 row = yield i
                 f.write(sep)
-                f.write(json.dumps(row))
+                f.write(orjson.dumps(row).decode('utf-8'))
                 sep = ',\n'
         finally:
             f.write('\n]')

--- a/common/tests/__fixtures__/utf-8-switched.json
+++ b/common/tests/__fixtures__/utf-8-switched.json
@@ -1,5 +1,5 @@
 [
-{"first": "\u1e1e\u014d\u00f6", "second": "\u0243\u00e0\u0155", "third": "\u1e06\u0101\u017e"},
-{"first": "foo", "second": "bar", "third": "baz"},
-{"first": "voo", "second": "par", "third": "paz"}
+{"first":"Ḟōö","second":"Ƀàŕ","third":"Ḇāž"},
+{"first":"foo","second":"bar","third":"baz"},
+{"first":"voo","second":"par","third":"paz"}
 ]

--- a/common/tests/__fixtures__/utf-8.json
+++ b/common/tests/__fixtures__/utf-8.json
@@ -1,5 +1,5 @@
 [
-{"col1": "\u1e1e\u014d\u00f6", "col2": "\u0243\u00e0\u0155", "col3": "\u1e06\u0101\u017e"},
-{"col1": "foo", "col2": "bar", "col3": "baz"},
-{"col1": "voo", "col2": "par", "col3": "paz"}
+{"col1":"Ḟōö","col2":"Ƀàŕ","col3":"Ḇāž"},
+{"col1":"foo","col2":"bar","col3":"baz"},
+{"col1":"voo","col2":"par","col3":"paz"}
 ]

--- a/common/tests/__fixtures__/utf-8.ndjson
+++ b/common/tests/__fixtures__/utf-8.ndjson
@@ -1,3 +1,3 @@
-{"col1": "\u1e1e\u014d\u00f6", "col2": "\u0243\u00e0\u0155", "col3": "\u1e06\u0101\u017e"}
-{"col1": "foo", "col2": "bar", "col3": "baz"}
-{"col1": "voo", "col2": "par", "col3": "paz"}
+{"col1":"Ḟōö","col2":"Ƀàŕ","col3":"Ḇāž"}
+{"col1":"foo","col2":"bar","col3":"baz"}
+{"col1":"voo","col2":"par","col3":"paz"}

--- a/complaints/ccdb/index_ccdb.py
+++ b/complaints/ccdb/index_ccdb.py
@@ -13,7 +13,7 @@ from common.es_proxy import (add_basic_es_arguments, get_aws_es_connection,
                              get_es_connection)
 from common.log import setup_logging
 
-BATCH_SIZE = os.getenv("BATCH_SIZE", 2000)
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", 2000))
 
 # -----------------------------------------------------------------------------
 # Enhancing Functions
@@ -181,7 +181,7 @@ def index_json_data(
             logger.info("chunk retrieved, now bulk load")
             success, _ = bulk(
                 es, actions=doc_ary, index=index_name,
-                chunk_size=chunk_size, refresh=True
+                chunk_size=chunk_size, refresh=False
             )
             total_rows_of_data += success
             logger.info(
@@ -189,6 +189,10 @@ def index_json_data(
                     success, total_rows_of_data
                 )
             )
+
+        logger.info(f"Refreshing index {index_name}")
+        es.indices.refresh(index=index_name)
+
         update_indexes_in_alias(
             es, logger, alias, backup_index_name, index_name
         )

--- a/complaints/ccdb/tests/test_index_ccdb.py
+++ b/complaints/ccdb/tests/test_index_ccdb.py
@@ -195,8 +195,11 @@ class TestMain(unittest.TestCase):
 
         # Bulk
         bulk.assert_called_once_with(
-            es, actions=ANY, index='onion-v1', chunk_size=2000, refresh=True
+            es, actions=ANY, index='onion-v1', chunk_size=2000, refresh=False
         )
+
+        # Index refresh call
+        es.indices.refresh.assert_called_once_with(index='onion-v1')
 
         self.validate_actions(toAbsolute('__fixtures__/exp_socrata.ndjson'))
 
@@ -250,8 +253,11 @@ class TestMain(unittest.TestCase):
 
         # Bulk
         bulk.assert_called_once_with(
-            es, actions=ANY, index='onion-v1', chunk_size=2000, refresh=True
+            es, actions=ANY, index='onion-v1', chunk_size=2000, refresh=False
         )
+
+        # Index refresh call
+        es.indices.refresh.assert_called_once_with(index='onion-v1')
 
         self.validate_actions(toAbsolute('__fixtures__/exp_s3.ndjson'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.37.38
 ConfigArgParse==0.14.0
 opensearch-py==3.0.0
-ijson==2.4
+orjson==3.11.7
 pytz
 requests==2.32.4
 requests_aws4auth


### PR DESCRIPTION
This PR attempts to speed up indexing:

1. Use orjson instead of json for speed (https://github.com/ijl/orjson).
2. Don't refresh each time we load into the index; we don't need to do this since the index isn't "activated" until we swap it when we're done loading. Instead we can do one big index refresh when we're done.
3. Fix minor bug when testing with `BATCH_SIZE` - without casting to int, this doesn't work properly.

I've also added the Zscaler public cert here from https://github.com/cfpb/zscaler-cert, to make it possible to build the Docker image on CFPB laptops.

From my local testing, the orjson change speeds up the CSV->JSON step significantly, about 40%. The indexing improvement is more minor, about 10% in my testing. This won't have a huge impact on the full runtime but should help a bit.