### PR TITLE
DATAP-2039/prevent blank complaint_ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,6 @@ coverage.xml
 salesforce_data.csv
 complaints.json
 complaints.json.zip
-complaints.csv.
+complaints.csv
 complaints.csv.zip
 to_index.json

--- a/complaints/ccdb/index_ccdb.py
+++ b/complaints/ccdb/index_ccdb.py
@@ -23,8 +23,13 @@ logger = setup_logging("index_ccdb")
 
 
 def enhance_complaint(complaint):
-    if "complaint_id" not in complaint:
-        complaint["complaint_id"] = complaint["public_id"]
+
+    if not complaint.get("complaint_id"):
+        if complaint.get("public_id"):
+            complaint["complaint_id"] = complaint["public_id"]
+        else:  # We must reject complaints with no public_id
+            logger.info(f"No public_id for complaint {complaint}")
+            return
 
     s = complaint.get("complaint_what_happened")
 
@@ -101,6 +106,8 @@ def data_load_strategy_complaint(data, transform_fn):
     with open(data) as f:
         for line in f:
             doc = transform_fn(json.loads(line))
+            if not doc:  # skip complaints that have no public_id
+                continue
             if doc["eligible"] == "true":
                 del doc["eligible"]
                 yield {"_op_type": "index", "_id": doc["complaint_id"], "_source": doc}
@@ -143,7 +150,7 @@ def update_index_with_data(es, data, index_name, chunk_size=BATCH_SIZE):
                     success, total_rows_of_data
                 )
             )
-        except errors.BulkIndexError as e:
+        except errors.BulkIndexError:
             pass
 
     logger.info(f"Refreshing index {index_name}")

--- a/complaints/ccdb/tests/test_index_ccdb.py
+++ b/complaints/ccdb/tests/test_index_ccdb.py
@@ -99,6 +99,21 @@ class TestIndexCCDB(unittest.TestCase):
         rest = [x for x in gen]
         self.assertEqual(rest, [["quux"]])
 
+    def test_enhance_complaint(self):
+        blank_public_id = {"public_id": "", "complaint_what_happened": "test"}
+        has_public_id = {
+            "public_id": "12345678", "complaint_what_happened": "test"
+        }
+        # success = {
+        #     "public_id": "12345678",
+        #     "complaint_what_happened": "test",
+        #     "complaint_id": "12345678"
+        # }
+        expected_failure = sut.enhance_complaint(blank_public_id)
+        self.assertIs(expected_failure, None)
+        expected = sut.enhance_complaint(has_public_id)
+        self.assertEqual(expected.get("complaint_id"), "12345678")
+
 
 class TestMain(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The public CSV posted 7/23/2026 had >11K records with null complaint_ids. 

This patch prevents such entries from being processed, since complaint_id is the primary key in OpenSearch documents.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Changed functions include new tests
